### PR TITLE
Update profile descriptions and research focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
       <div class="column is-7 content">
         <!-- <h4>Research Theme</h4> -->
         <p>
-          Shuntaro Yada is an associate professor at the University of Tsukuba, where he leads the <strong><a href="https://kalc.slis.tsukuba.ac.jp" target="_blank">Knowledge and Language Computing Laboratory (KaLC Lab)</a></strong> within the Institute of Library, Information and Media Science.
+          Shuntaro Yada is an associate professor at the University of Tsukuba, where he leads the <a href="https://kalc.slis.tsukuba.ac.jp" target="_blank" rel="noopener noreferrer"><strong>Knowledge and Language Computing Laboratory (KaLC Lab)</strong></a> within the Institute of Library, Information and Media Science.
           He also serves as a Vice Director at the Office of International Online Education in the university.
           He received his PhD from the University of Tokyo Graduate School of Education in 2020.
         </p>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
           His work extends to social computing applications such as book recommendation systems for school libraries (<a href="https://bookreach.org" target="_blank" rel="noopener noreferrer"><strong>BookReach</strong></a>) and <a href="https://yamai-taikenki.naist.jp" target="_blank" rel="noopener noreferrer">search engines for illness experience narratives</a>, bridging medical informatics with library science methodologies.
         </p>
         <p>
-          His latest funded project, selected for the 2024 <a href="https://www.jst.go.jp/souhatsu/en/index.html" target="_blank">JST FOREST Program</a>, is titled "Integration of Knowledge Across All Academic Fields through Automatic Construction of Specialised Terminology Dictionaries."
+          His latest funded project, selected for the 2024 <a href="https://www.jst.go.jp/souhatsu/en/index.html" target="_blank" rel="noopener noreferrer">JST FOREST Program</a>, is titled "Integration of Knowledge Across All Academic Fields through Automatic Construction of Specialised Terminology Dictionaries."
           This project aims to leverage language processing technology to build comprehensive terminology resources that span diverse knowledge domains, from medicine and science to law, economics, and the arts.
           This direction represents a natural expansion of his long-standing expertise in domain-specific language processing towards a broader, cross-disciplinary vision.
         </p>

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
         <p>
           His research interests lie at the intersection of natural language processing, medical informatics, and library and information science.
           He has developed practical systems for processing clinical texts, including the <a href="https://aoi.naist.jp/prism-heart" target="_blank" rel="noopener noreferrer"><strong>HeaRT</strong></a> system for electronic medical records and tools for extracting structured information from patient narratives on social media.
-          His work extends to social computing applications such as book recommendation systems for school libraries (<a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>) and <a href="https://yamai-taikenki.naist.jp" target="_blank">search engines for illness experience narratives</a>, bridging medical informatics with library science methodologies.
+          His work extends to social computing applications such as book recommendation systems for school libraries (<a href="https://bookreach.org" target="_blank" rel="noopener noreferrer"><strong>BookReach</strong></a>) and <a href="https://yamai-taikenki.naist.jp" target="_blank" rel="noopener noreferrer">search engines for illness experience narratives</a>, bridging medical informatics with library science methodologies.
         </p>
         <p>
           His latest funded project, selected for the 2024 <a href="https://www.jst.go.jp/souhatsu/en/index.html" target="_blank">JST FOREST Program</a>, is titled "Integration of Knowledge Across All Academic Fields through Automatic Construction of Specialised Terminology Dictionaries."

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
         <div class="column is-narrow is-three-fifths-tablet">
           <div class="box">
             <p>
-              I am an associate professor working on <strong>library and information science</strong> and <strong>medical language processing</strong> at the <strong>University of Tsukuba</strong> in Japan,
+              I am an associate professor at the <strong>University of Tsukuba</strong> in Japan, working at the intersection of <strong>natural language processing</strong>, <strong>medical informatics</strong>, and <strong>library and information science</strong>,
               leading the <strong>Knowledge and Language Computing Laboratory (KaLC Lab)</strong>.
             </p>
             <p class="mt-3 mb-3">
@@ -181,20 +181,19 @@
       <div class="column is-7 content">
         <!-- <h4>Research Theme</h4> -->
         <p>
-          He specialises in social computing on social media and the application of natural language processing, and is currently engaged in medical language processing, drawing on his experience.
-          In particular, he is researching and developing a system that extracts medical information from clinical documents (e.g. electronic health records; EHRs) as graphs to facilitate information sharing among healthcare professionals or between patients and them.
-          Examples of such systems include a system that searches for radiology reports with similar diagnostic content and the <a href="https://aoi.naist.jp/prism-heart" target="_blank"><strong>HeaRT</strong></a> system (Japanese patent pending) which creates a timeline of a patient's treatment history from written text in EHRs.
-          Annotated training data (corpora) are essential for the language processing models behind these systems, the annotations of which he has designed and built over several projects.
+          Shuntaro Yada is an associate professor at the University of Tsukuba, where he leads the <strong><a href="https://kalc.slis.tsukuba.ac.jp" target="_blank">Knowledge and Language Computing Laboratory (KaLC Lab)</a></strong> within the Institute of Library, Information and Media Science.
+          He also serves as a Vice Director at the Office of International Online Education in the university.
+          He received his PhD from the University of Tokyo Graduate School of Education in 2020.
         </p>
         <p>
-          In his library and information science major, he is interested in creating a digital environment where people can encounter valuable information even passively.
-          <strong>Serendy</strong>, a word-of-mouth book recommendation system that inspires those who are unsure of what to read, promotes chance encounters by delivering information on books mentioned by acquaintances and friends on social media such as Twitter.
-          <a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>, a system that helps school librarians support classes, allows them to search through related materials according to class units, providing opportunities to encounter unexpectedly useful books.
-          From 2023, we are also developing and operating <a href="https://yamai-taikenki.naist.jp" target="_blank">a book search engine</a> in Japan, which enables searching for books that provide emotional support for people with cancer and other intractable diseases.
+          His research interests lie at the intersection of natural language processing, medical informatics, and library and information science.
+          He has developed practical systems for processing clinical texts, including the <a href="https://aoi.naist.jp/prism-heart" target="_blank"><strong>HeaRT</strong></a> system for electronic medical records and tools for extracting structured information from patient narratives on social media.
+          His work extends to social computing applications such as book recommendation systems for school libraries (<a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>) and <a href="https://yamai-taikenki.naist.jp" target="_blank">search engines for illness experience narratives</a>, bridging medical informatics with library science methodologies.
         </p>
         <p>
-          Since 2025, as a principal investigator, he has established a new lab called the <strong><a href="https://kalc.slis.tsukuba.ac.jp" target="_blank">Knowledge and Language Computing Laboratory (KaLC Lab)</a></strong> at the University of Tsukuba.
-          Building on his expertise in the domains of medicine and education, he aims to expand his research into other knowledge areas such as science, industry, law, economics, culture, and art, leveraging language processing technology as a core methodology.
+          His latest funded project, selected for the 2024 <a href="https://www.jst.go.jp/souhatsu/en/index.html" target="_blank">JST FOREST Program</a>, is titled "Integration of Knowledge Across All Academic Fields through Automatic Construction of Specialised Terminology Dictionaries."
+          This project aims to leverage language processing technology to build comprehensive terminology resources that span diverse knowledge domains, from medicine and science to law, economics, and the arts.
+          This direction represents a natural expansion of his long-standing expertise in domain-specific language processing towards a broader, cross-disciplinary vision.
         </p>
 
         <div class="columns">

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
         </p>
         <p>
           His research interests lie at the intersection of natural language processing, medical informatics, and library and information science.
-          He has developed practical systems for processing clinical texts, including the <a href="https://aoi.naist.jp/prism-heart" target="_blank"><strong>HeaRT</strong></a> system for electronic medical records and tools for extracting structured information from patient narratives on social media.
+          He has developed practical systems for processing clinical texts, including the <a href="https://aoi.naist.jp/prism-heart" target="_blank" rel="noopener noreferrer"><strong>HeaRT</strong></a> system for electronic medical records and tools for extracting structured information from patient narratives on social media.
           His work extends to social computing applications such as book recommendation systems for school libraries (<a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>) and <a href="https://yamai-taikenki.naist.jp" target="_blank">search engines for illness experience narratives</a>, bridging medical informatics with library science methodologies.
         </p>
         <p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -191,7 +191,7 @@
           また、学校図書館向け図書推薦システム<a href="https://bookreach.org" target="_blank" rel="noopener noreferrer"><strong>BookReach</strong></a>や<a href="https://yamai-taikenki.naist.jp" target="_blank" rel="noopener noreferrer"><strong>病の体験記サーチ</strong></a>など、ソーシャル・コンピューティングの応用にも研究を展開し、医療情報学と図書館情報学の方法論を橋渡ししています。
         </p>
         <p class="lang-ja has-text-justified">
-          最新の研究プロジェクトは、2024年度<a href="https://www.jst.go.jp/souhatsu/call/sel24.html" target="_blank">JST創発的研究支援事業</a>に採択された「専門用語辞典の自動構築による全学術分野の知の統合」です。
+          最新の研究プロジェクトは、2024年度<a href="https://www.jst.go.jp/souhatsu/call/sel24.html" target="_blank" rel="noopener noreferrer">JST創発的研究支援事業</a>に採択された「専門用語辞典の自動構築による全学術分野の知の統合」です。
           本プロジェクトは、言語処理技術を活用して、医学や科学から法律、経済、芸術に至るまでの多様な知識領域を横断する包括的な用語資源の構築を目指しています。
           この方向性は、領域特化型言語処理における長年の専門性を、より広く分野横断的なビジョンへと自然に拡張するものです。
         </p>

--- a/ja/index.html
+++ b/ja/index.html
@@ -187,7 +187,7 @@
         </p>
         <p class="lang-ja has-text-justified">
           研究分野は自然言語処理、医療情報学、図書館情報学の交差領域にあります。
-          電子カルテなどの臨床テキストを処理する実用的なシステムの開発に取り組んでおり、電子カルテ用の<a href="https://aoi.naist.jp/prism-heart" target="_blank"><strong>HeaRT</strong></a>システムや、ソーシャルメディア上の患者の語りから構造化情報を抽出するツールなどがあります。
+          電子カルテなどの臨床テキストを処理する実用的なシステムの開発に取り組んでおり、電子カルテ用の<a href="https://aoi.naist.jp/prism-heart" target="_blank" rel="noopener noreferrer"><strong>HeaRT</strong></a>システムや、ソーシャルメディア上の患者の語りから構造化情報を抽出するツールなどがあります。
           また、学校図書館向け図書推薦システム<a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>や<a href="https://yamai-taikenki.naist.jp" target="_blank"><strong>病の体験記サーチ</strong></a>など、ソーシャル・コンピューティングの応用にも研究を展開し、医療情報学と図書館情報学の方法論を橋渡ししています。
         </p>
         <p class="lang-ja has-text-justified">

--- a/ja/index.html
+++ b/ja/index.html
@@ -132,8 +132,8 @@
         <div class="column is-narrow is-three-fifths-tablet">
           <div class="box">
             <p>
-              <strong>図書館情報学</strong>と<strong>医療言語処理</strong>を専門とし、
-              筑波大学 准教授として<strong>知識と言葉のコンピューティング研究室 (KaLC Lab)</strong> を運営しています。
+              <strong>自然言語処理</strong>・<strong>医療情報学</strong>・<strong>図書館情報学</strong>の交差領域を専門とし、
+              筑波大学 准教授として<strong>知識と言葉のコンピューティング研究室 (KaLC Lab)</strong> を主宰しています。
             </p>
             <p class="mt-3 mb-3">
               <a href="/" class="button is-small is-outlined is-white">
@@ -181,20 +181,19 @@
       <div class="column is-7 content">
         <!-- <h4>研究テーマ</h4> -->
         <p class="lang-ja has-text-justified">
-          SNSを活用したソーシャル・コンピューティングや自然言語処理の応用を専門とし、その経験を生かして現在は医療言語処理にも従事しています。
-          特に、臨床現場で書かれる電子カルテ等のテキストから医療情報をグラフとして抽出し、医療従事者同士および患者との情報共有を促進するシステムを研究開発しています。
-          診断内容が類似した読影所見を検索するシステムや、電子カルテにテキストで書かれた患者の治療歴をタイムライン化する <a href="https://aoi.naist.jp/prism-heart" target="_blank"><strong>HeaRT</strong></a> (特許出願中) などはその例です。
-          こうしたシステムの背後で動く言語処理モデルにはアノテーションされた訓練データ（コーパス）が不可欠ですが、私は複数プロジェクトに亘ってその仕様から策定し構築してきました。
+          矢田竣太郎は、筑波大学図書館情報メディア系の准教授であり、<strong><a href="https://kalc.slis.tsukuba.ac.jp/ja/" target="_blank">知識と言葉のコンピューティング研究室（KaLC Lab）</a></strong>を主宰しています。
+          また、同大学のJV-Campus連携室（国際オンライン教育推進室）の副室長も務めています。
+          2020年に東京大学大学院教育学研究科にて博士号（教育学）を取得しました。
         </p>
         <p class="lang-ja has-text-justified">
-          専攻である図書館情報学においては、受動的にでも価値ある情報と出会えるデジタル環境づくりに関心を持っています。
-          「何を読めばよいかわからない」と悩む人々を読書へと触発する図書クチコミ推薦システム <strong>Serendy</strong> では、Twitter のようなSNS上で知人・友人が言及した図書の情報を届けることで、偶然の出会いを促進します。
-          学校図書館で働く司書による授業支援を手助けするシステム <a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a> では、授業の単元に応じて関連資料を一覧しながら探せるようにして、思わぬ有用図書との遭遇機会を提供します。
-          2023年からは、がんなどの難病とともに生きる人々にとって心の支えとなるような図書を探せる<a href="https://yamai-taikenki.naist.jp" target="_blank"><strong>病の体験記サーチ</strong></a>も開発・運営中です。
+          研究分野は自然言語処理、医療情報学、図書館情報学の交差領域にあります。
+          電子カルテなどの臨床テキストを処理する実用的なシステムの開発に取り組んでおり、電子カルテ用の<a href="https://aoi.naist.jp/prism-heart" target="_blank"><strong>HeaRT</strong></a>システムや、ソーシャルメディア上の患者の語りから構造化情報を抽出するツールなどがあります。
+          また、学校図書館向け図書推薦システム<a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>や<a href="https://yamai-taikenki.naist.jp" target="_blank"><strong>病の体験記サーチ</strong></a>など、ソーシャル・コンピューティングの応用にも研究を展開し、医療情報学と図書館情報学の方法論を橋渡ししています。
         </p>
         <p class="lang-ja has-text-justified">
-          2025年より、PIとして筑波大学に<strong><a href="https://kalc.slis.tsukuba.ac.jp/ja/" target="_blank">知識と言葉のコンピューティング研究室 (KaLC Lab)</a></strong> を設立しました。
-          医療や教育の分野で培った経験を基盤に、科学、産業、法律、経済、文化、芸術など、他の幅広い知識領域へと研究対象を拡大し、言語処理技術を核とした研究を推進していきます。
+          最新の研究プロジェクトは、2024年度<a href="https://www.jst.go.jp/souhatsu/call/sel24.html" target="_blank">JST創発的研究支援事業</a>に採択された「専門用語辞典の自動構築による全学術分野の知の統合」です。
+          本プロジェクトは、言語処理技術を活用して、医学や科学から法律、経済、芸術に至るまでの多様な知識領域を横断する包括的な用語資源の構築を目指しています。
+          この方向性は、領域特化型言語処理における長年の専門性を、より広く分野横断的なビジョンへと自然に拡張するものです。
         </p>
 
         <div class="columns">

--- a/ja/index.html
+++ b/ja/index.html
@@ -188,7 +188,7 @@
         <p class="lang-ja has-text-justified">
           研究分野は自然言語処理、医療情報学、図書館情報学の交差領域にあります。
           電子カルテなどの臨床テキストを処理する実用的なシステムの開発に取り組んでおり、電子カルテ用の<a href="https://aoi.naist.jp/prism-heart" target="_blank" rel="noopener noreferrer"><strong>HeaRT</strong></a>システムや、ソーシャルメディア上の患者の語りから構造化情報を抽出するツールなどがあります。
-          また、学校図書館向け図書推薦システム<a href="https://bookreach.org" target="_blank"><strong>BookReach</strong></a>や<a href="https://yamai-taikenki.naist.jp" target="_blank"><strong>病の体験記サーチ</strong></a>など、ソーシャル・コンピューティングの応用にも研究を展開し、医療情報学と図書館情報学の方法論を橋渡ししています。
+          また、学校図書館向け図書推薦システム<a href="https://bookreach.org" target="_blank" rel="noopener noreferrer"><strong>BookReach</strong></a>や<a href="https://yamai-taikenki.naist.jp" target="_blank" rel="noopener noreferrer"><strong>病の体験記サーチ</strong></a>など、ソーシャル・コンピューティングの応用にも研究を展開し、医療情報学と図書館情報学の方法論を橋渡ししています。
         </p>
         <p class="lang-ja has-text-justified">
           最新の研究プロジェクトは、2024年度<a href="https://www.jst.go.jp/souhatsu/call/sel24.html" target="_blank">JST創発的研究支援事業</a>に採択された「専門用語辞典の自動構築による全学術分野の知の統合」です。


### PR DESCRIPTION
## Summary
Updated the biographical and research descriptions on both Japanese and English versions of the website to reflect current research directions and institutional roles.

## Key Changes

- **Refined research focus**: Changed from "Library and Information Science" and "Medical Language Processing" to emphasize the intersection of "Natural Language Processing", "Medical Informatics", and "Library and Information Science"
- **Updated institutional description**: Clarified role as associate professor at University of Tsukuba's Institute of Library, Information and Media Science and added mention of Vice Director position at the Office of International Online Education
- **Reorganized profile content**: Restructured the biographical paragraphs to lead with current position and credentials (PhD from University of Tokyo, 2020)
- **Refocused research narrative**: Shifted from detailed system descriptions to a more cohesive narrative about bridging medical informatics and library science methodologies
- **Updated latest project**: Replaced reference to lab establishment in 2025 with current 2024 JST FOREST Program funding for "Integration of Knowledge Across All Academic Fields through Automatic Construction of Specialised Terminology Dictionaries"
- **Improved language**: Changed "運営" to "主宰" (presides over) in Japanese for more formal terminology; updated English phrasing for clarity and consistency

## Notable Details

- Both Japanese (ja/index.html) and English (index.html) versions were updated in parallel to maintain consistency
- The changes emphasize a broader, cross-disciplinary vision while maintaining focus on core expertise in language processing and domain-specific applications
- Removed outdated references to lab establishment and replaced with current funded research initiatives

https://claude.ai/code/session_012w6HAistY5sUwgk8177C2u